### PR TITLE
Add PlaceVisit feature: multi-visit tracking per place

### DIFF
--- a/src/main/java/places/migration/PlaceVisitMigration.java
+++ b/src/main/java/places/migration/PlaceVisitMigration.java
@@ -1,0 +1,92 @@
+package places.migration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import places.model.Place;
+import places.model.PlaceVisit;
+import places.model.UserVisit;
+import places.model.VisitInvitation;
+import places.model.VisitStatus;
+import places.repository.PlaceRepository;
+import places.repository.PlaceVisitRepository;
+import places.repository.UserVisitRepository;
+import places.repository.VisitInvitationRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlaceVisitMigration {
+
+    private final PlaceRepository placeRepository;
+    private final PlaceVisitRepository placeVisitRepository;
+    private final UserVisitRepository userVisitRepository;
+    private final VisitInvitationRepository visitInvitationRepository;
+
+    // @EventListener(ApplicationReadyEvent.class)
+    public void migrate() {
+        log.info("Starting PlaceVisit migration...");
+
+        // 1. For each Place without visitCount (null): create initial PlaceVisit
+        List<Place> places = placeRepository.findAll();
+        for (Place place : places) {
+            if (place.getVisitCount() == null) {
+                log.info("Migrating place: {}", place.getId());
+
+                List<PlaceVisit> existingVisits = placeVisitRepository.findByPlaceIdOrderByVisitedAtDesc(place.getId());
+                if (existingVisits.isEmpty()) {
+                    PlaceVisit initialVisit = new PlaceVisit();
+                    initialVisit.setId(UUID.randomUUID().toString().split("-")[0]);
+                    initialVisit.setPlaceId(place.getId());
+                    initialVisit.setUserId(place.getUserId());
+                    initialVisit.setVisitedAt(place.getVisitedAt());
+                    initialVisit.setOwnerRating(place.getRating());
+                    placeVisitRepository.save(initialVisit);
+                    log.info("Created initial PlaceVisit for place: {}", place.getId());
+                }
+
+                // Update place summary fields
+                place.setVisitCount(1);
+                place.setAverageRating(place.getRating());
+                place.setLatestVisitedAt(place.getVisitedAt());
+                placeRepository.save(place);
+            }
+        }
+
+        // 2. For each UserVisit without placeVisitId: find PlaceVisit for the place and link
+        List<UserVisit> userVisits = userVisitRepository.findAll();
+        for (UserVisit userVisit : userVisits) {
+            if (userVisit.getPlaceVisitId() == null && userVisit.getStatus() == VisitStatus.VISITED) {
+                Optional<PlaceVisit> placeVisitOpt = placeVisitRepository
+                        .findFirstByPlaceIdOrderByVisitedAtDesc(userVisit.getPlaceId());
+                placeVisitOpt.ifPresent(pv -> {
+                    userVisit.setPlaceVisitId(pv.getId());
+                    userVisitRepository.save(userVisit);
+                    log.info("Linked UserVisit {} to PlaceVisit {}", userVisit.getId(), pv.getId());
+                });
+            }
+        }
+
+        // 3. For each VisitInvitation without placeVisitId: link to latest PlaceVisit
+        List<VisitInvitation> invitations = visitInvitationRepository.findAll();
+        for (VisitInvitation invitation : invitations) {
+            if (invitation.getPlaceVisitId() == null) {
+                Optional<PlaceVisit> placeVisitOpt = placeVisitRepository
+                        .findFirstByPlaceIdOrderByVisitedAtDesc(invitation.getPlaceId());
+                placeVisitOpt.ifPresent(pv -> {
+                    invitation.setPlaceVisitId(pv.getId());
+                    visitInvitationRepository.save(invitation);
+                    log.info("Linked VisitInvitation {} to PlaceVisit {}", invitation.getId(), pv.getId());
+                });
+            }
+        }
+
+        log.info("PlaceVisit migration complete.");
+    }
+}

--- a/src/main/java/places/model/ConsumedItem.java
+++ b/src/main/java/places/model/ConsumedItem.java
@@ -1,0 +1,22 @@
+package places.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumedItem {
+
+    private String id;
+    private String name;
+    private ItemCategory category;
+    private String notes;
+    @Builder.Default
+    private List<String> photoUrls = new ArrayList<>();
+}

--- a/src/main/java/places/model/InviteRequest.java
+++ b/src/main/java/places/model/InviteRequest.java
@@ -8,4 +8,5 @@ import lombok.NoArgsConstructor;
 public class InviteRequest {
     private String placeId;
     private String inviteeId;
+    private String placeVisitId; // nullable
 }

--- a/src/main/java/places/model/ItemCategory.java
+++ b/src/main/java/places/model/ItemCategory.java
@@ -1,0 +1,8 @@
+package places.model;
+
+public enum ItemCategory {
+    FOOD,
+    DRINK,
+    DESSERT,
+    OTHER
+}

--- a/src/main/java/places/model/Place.java
+++ b/src/main/java/places/model/Place.java
@@ -37,6 +37,10 @@ public class Place {
     private LocalDateTime visitedAt;
     private Boolean isFavorite;
 
+    private Integer visitCount;
+    private Rating averageRating;
+    private LocalDateTime latestVisitedAt;
+
     private String ownershipTransferredFromName;
     private LocalDateTime ownershipTransferredAt;
 

--- a/src/main/java/places/model/PlaceResponse.java
+++ b/src/main/java/places/model/PlaceResponse.java
@@ -36,6 +36,10 @@ public class PlaceResponse {
     private String visitId;
     private String ownershipTransferredFromName;
     private LocalDateTime ownershipTransferredAt;
+    private Integer visitCount;
+    private Rating averageRating;
+    private LocalDateTime latestVisitedAt;
+    private List<PlaceVisitResponse> visits; // null for list view, populated for detail
 
     public static PlaceResponse fromPlace(Place place, List<CoVisitor> coVisitors) {
         return PlaceResponse.builder()
@@ -61,6 +65,9 @@ public class PlaceResponse {
                 .coVisitors(coVisitors)
                 .ownershipTransferredFromName(place.getOwnershipTransferredFromName())
                 .ownershipTransferredAt(place.getOwnershipTransferredAt())
+                .visitCount(place.getVisitCount())
+                .averageRating(place.getAverageRating())
+                .latestVisitedAt(place.getLatestVisitedAt())
                 .build();
     }
 }

--- a/src/main/java/places/model/PlaceSorting.java
+++ b/src/main/java/places/model/PlaceSorting.java
@@ -6,5 +6,6 @@ public enum PlaceSorting {
     RATING_ASC,
     RATING_DESC,
     DATE_ASC,
-    DATE_DESC
+    DATE_DESC,
+    MOST_VISITS
 }

--- a/src/main/java/places/model/PlaceVisit.java
+++ b/src/main/java/places/model/PlaceVisit.java
@@ -1,6 +1,8 @@
 package places.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -8,19 +10,21 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-@Document(collection = "user_visits")
 @Data
-public class UserVisit {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "place_visits")
+public class PlaceVisit {
 
     @Id
     private String id;
     private String placeId;
     private String userId;
-    private Rating rating;
     private LocalDateTime visitedAt;
-    private VisitStatus status;
-    private String placeVisitId; // nullable, backward compat
+    private Rating ownerRating;
+    @Builder.Default
+    private List<ConsumedItem> consumedItems = new ArrayList<>();
+    @Builder.Default
+    private List<String> photoUrls = new ArrayList<>();
 }

--- a/src/main/java/places/model/PlaceVisitResponse.java
+++ b/src/main/java/places/model/PlaceVisitResponse.java
@@ -1,0 +1,15 @@
+package places.model;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceVisitResponse {
+
+    private PlaceVisit visit;
+    private List<CoVisitor> coVisitors;
+}

--- a/src/main/java/places/model/VisitInvitation.java
+++ b/src/main/java/places/model/VisitInvitation.java
@@ -23,4 +23,5 @@ public class VisitInvitation {
     private String inviteeId;
     private InvitationStatus status;
     private LocalDateTime createdAt;
+    private String placeVisitId; // nullable, backward compat
 }

--- a/src/main/java/places/repository/PlaceVisitRepository.java
+++ b/src/main/java/places/repository/PlaceVisitRepository.java
@@ -1,0 +1,20 @@
+package places.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import places.model.PlaceVisit;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PlaceVisitRepository extends MongoRepository<PlaceVisit, String> {
+
+    List<PlaceVisit> findByPlaceIdOrderByVisitedAtDesc(String placeId);
+
+    List<PlaceVisit> findByUserId(String userId);
+
+    Optional<PlaceVisit> findFirstByPlaceIdOrderByVisitedAtDesc(String placeId);
+
+    void deleteByPlaceId(String placeId);
+}

--- a/src/main/java/places/repository/qdls/PlaceRepositoryCustomImpl.java
+++ b/src/main/java/places/repository/qdls/PlaceRepositoryCustomImpl.java
@@ -43,6 +43,9 @@ public class PlaceRepositoryCustomImpl implements PlaceRepositoryCustom {
             case DATE_DESC:
                 orders.add(Sort.Order.desc("visitedAt"));
                 break;
+            case MOST_VISITS:
+                orders.add(Sort.Order.desc("visitCount"));
+                break;
             default:
                 throw new IllegalArgumentException("Invalid sorting method");
         }

--- a/src/main/java/places/rest/VisitController.java
+++ b/src/main/java/places/rest/VisitController.java
@@ -2,26 +2,39 @@ package places.rest;
 
 import static places.constants.Constants.REST_URL;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import places.model.InviteRequest;
 import places.model.PlaceResponse;
+import places.model.PlaceVisit;
+import places.model.PlaceVisitResponse;
 import places.model.Rating;
 import places.model.User;
 import places.model.UserVisit;
 import places.model.VisitInvitation;
 import places.model.VisitInvitationDto;
+import places.service.PlaceManager;
 import places.service.VisitInvitationManager;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestController
 @RequestMapping(value = REST_URL)
 public class VisitController {
@@ -32,15 +45,20 @@ public class VisitController {
     public static final String DECLINE_INVITATION = "/visits/invitations/{invitationId}/decline";
     public static final String RATE_VISIT = "/visits/{visitId}/rate";
     public static final String REMOVE_CO_VISITOR = "/visits/{placeId}/co-visitors/{coVisitorUserId}/remove";
+    public static final String PLACE_VISITS = "/visits/place-visits";
+    public static final String PLACE_VISITS_BY_PLACE = "/visits/place-visits/{placeId}";
+    public static final String PLACE_VISIT_BY_ID = "/visits/place-visits/visit/{visitId}";
+    public static final String PLACE_VISIT_PHOTOS = "/visits/place-visits/visit/{visitId}/photos";
+    public static final String CONSUMED_ITEM_PHOTOS = "/visits/place-visits/visit/{visitId}/items/{itemId}/photos";
 
-    @Autowired
-    private VisitInvitationManager visitInvitationManager;
+    private final VisitInvitationManager visitInvitationManager;
+    private final PlaceManager placeManager;
 
     @PostMapping(value = SEND_INVITATION)
     public VisitInvitation sendInvitation(@RequestBody InviteRequest request) {
         User loggedUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return visitInvitationManager.sendInvitation(
-                loggedUser.getId(), request.getPlaceId(), request.getInviteeId());
+                loggedUser.getId(), request.getPlaceId(), request.getInviteeId(), request.getPlaceVisitId());
     }
 
     @GetMapping(value = GET_PENDING_INVITATIONS)
@@ -67,5 +85,45 @@ public class VisitController {
     public PlaceResponse removeCoVisitor(@PathVariable String placeId, @PathVariable String coVisitorUserId) {
         User loggedUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return visitInvitationManager.removeCoVisitor(placeId, coVisitorUserId, loggedUser.getId());
+    }
+
+    // ─── PlaceVisit endpoints ────────────────────────────────────────────────
+
+    @PostMapping(value = PLACE_VISITS)
+    @ResponseStatus(HttpStatus.CREATED)
+    public PlaceVisitResponse createPlaceVisit(@RequestBody PlaceVisit placeVisit) {
+        return placeManager.createPlaceVisit(placeVisit);
+    }
+
+    @GetMapping(value = PLACE_VISITS_BY_PLACE)
+    public List<PlaceVisitResponse> getPlaceVisits(@PathVariable String placeId) {
+        return placeManager.getPlaceVisits(placeId);
+    }
+
+    @PatchMapping(value = PLACE_VISIT_BY_ID)
+    public PlaceVisitResponse updatePlaceVisit(@PathVariable String visitId, @RequestBody PlaceVisit updates) {
+        return placeManager.updatePlaceVisit(visitId, updates);
+    }
+
+    @DeleteMapping(value = PLACE_VISIT_BY_ID)
+    public void deletePlaceVisit(@PathVariable String visitId) {
+        placeManager.deletePlaceVisit(visitId);
+    }
+
+    @PostMapping(value = PLACE_VISIT_PHOTOS)
+    public ResponseEntity<Map<String, String>> uploadPlaceVisitPhoto(
+            @PathVariable String visitId,
+            @RequestParam("file") MultipartFile file) throws IOException {
+        String url = placeManager.uploadPlaceVisitPhoto(visitId, file.getBytes(), file.getOriginalFilename());
+        return ResponseEntity.ok(Map.of("photoUrl", url));
+    }
+
+    @PostMapping(value = CONSUMED_ITEM_PHOTOS)
+    public ResponseEntity<Map<String, String>> uploadConsumedItemPhoto(
+            @PathVariable String visitId,
+            @PathVariable String itemId,
+            @RequestParam("file") MultipartFile file) throws IOException {
+        String url = placeManager.uploadConsumedItemPhoto(visitId, itemId, file.getBytes(), file.getOriginalFilename());
+        return ResponseEntity.ok(Map.of("photoUrl", url));
     }
 }

--- a/src/main/java/places/service/PlaceManager.java
+++ b/src/main/java/places/service/PlaceManager.java
@@ -2,6 +2,8 @@ package places.service;
 
 import places.model.Place;
 import places.model.PlaceResponse;
+import places.model.PlaceVisit;
+import places.model.PlaceVisitResponse;
 import java.util.List;
 import places.model.PlaceSearchForm;
 
@@ -12,4 +14,12 @@ public interface PlaceManager {
     List<PlaceResponse> findSharedPlaces(String userId);
     String deletePlace(String placeId, String requestingUserId);
     void acknowledgeOwnershipTransfer(String placeId);
+
+    // PlaceVisit operations
+    PlaceVisitResponse createPlaceVisit(PlaceVisit placeVisit);
+    List<PlaceVisitResponse> getPlaceVisits(String placeId);
+    PlaceVisitResponse updatePlaceVisit(String visitId, PlaceVisit updates);
+    void deletePlaceVisit(String visitId);
+    String uploadPlaceVisitPhoto(String visitId, byte[] fileBytes, String fileName) throws java.io.IOException;
+    String uploadConsumedItemPhoto(String visitId, String itemId, byte[] fileBytes, String fileName) throws java.io.IOException;
 }

--- a/src/main/java/places/service/PlaceManagerImpl.java
+++ b/src/main/java/places/service/PlaceManagerImpl.java
@@ -1,5 +1,9 @@
 package places.service;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -8,14 +12,21 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import places.model.CoVisitor;
+import places.model.ConsumedItem;
 import places.model.Place;
 import places.model.PlaceResponse;
 import places.model.PlaceSearchForm;
+import places.model.PlaceVisit;
+import places.model.PlaceVisitResponse;
+import places.model.Rating;
 import places.model.UserVisit;
 import places.model.VisitStatus;
 import places.repository.PlaceRepository;
+import places.repository.PlaceVisitRepository;
 import places.repository.UserRepository;
 import places.repository.UserVisitRepository;
 
@@ -31,12 +42,29 @@ public class PlaceManagerImpl implements PlaceManager {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private PlaceVisitRepository placeVisitRepository;
+
     @Override
     public PlaceResponse saveOrUpdatePlace(Place place) {
-        if (place.getId() == null) {
+        boolean isNew = place.getId() == null;
+        if (isNew) {
             place.setId(UUID.randomUUID().toString().split("-")[0]);
         }
         Place saved = placeRepository.save(place);
+
+        if (isNew && saved.getRating() != null && saved.getVisitedAt() != null) {
+            PlaceVisit initialVisit = new PlaceVisit();
+            initialVisit.setId(UUID.randomUUID().toString().split("-")[0]);
+            initialVisit.setPlaceId(saved.getId());
+            initialVisit.setUserId(saved.getUserId());
+            initialVisit.setVisitedAt(saved.getVisitedAt());
+            initialVisit.setOwnerRating(saved.getRating());
+            placeVisitRepository.save(initialVisit);
+            computePlaceSummary(saved.getId());
+            saved = placeRepository.findById(saved.getId()).orElse(saved);
+        }
+
         return PlaceResponse.fromPlace(saved, new ArrayList<>());
     }
 
@@ -44,7 +72,11 @@ public class PlaceManagerImpl implements PlaceManager {
     public List<PlaceResponse> findAllPlaces(PlaceSearchForm placeSearchForm, String userId) {
         List<Place> places = placeRepository.findPlacesBySearchForm(placeSearchForm, userId);
         return places.stream()
-                .map(place -> PlaceResponse.fromPlace(place, assembleCoVisitors(place.getId())))
+                .map(place -> {
+                    PlaceResponse response = PlaceResponse.fromPlace(place, assembleCoVisitors(place.getId()));
+                    response.setVisits(getPlaceVisits(place.getId()));
+                    return response;
+                })
                 .collect(Collectors.toList());
     }
 
@@ -52,7 +84,11 @@ public class PlaceManagerImpl implements PlaceManager {
     public List<PlaceResponse> findFavoritePlaces(String userId) {
         List<Place> places = placeRepository.findByUserIdAndIsFavorite(userId, true);
         return places.stream()
-                .map(place -> PlaceResponse.fromPlace(place, assembleCoVisitors(place.getId())))
+                .map(place -> {
+                    PlaceResponse response = PlaceResponse.fromPlace(place, assembleCoVisitors(place.getId()));
+                    response.setVisits(getPlaceVisits(place.getId()));
+                    return response;
+                })
                 .collect(Collectors.toList());
     }
 
@@ -66,6 +102,7 @@ public class PlaceManagerImpl implements PlaceManager {
                     PlaceResponse response = PlaceResponse.fromPlace(place, assembleCoVisitors(place.getId()));
                     response.setRating(myVisit.getRating());
                     response.setVisitId(myVisit.getId());
+                    response.setVisits(getPlaceVisits(place.getId()));
                     return response;
                 })
                 .filter(r -> r != null)
@@ -86,6 +123,7 @@ public class PlaceManagerImpl implements PlaceManager {
                 Comparator.nullsLast(Comparator.naturalOrder())));
 
         if (coVisitorVisits.isEmpty()) {
+            placeVisitRepository.deleteByPlaceId(placeId);
             userVisitRepository.deleteByPlaceId(placeId);
             placeRepository.deleteById(placeId);
             return "DELETED";
@@ -116,6 +154,160 @@ public class PlaceManagerImpl implements PlaceManager {
         });
     }
 
+    // ─── PlaceVisit CRUD ──────────────────────────────────────────────────────
+
+    @Override
+    public PlaceVisitResponse createPlaceVisit(PlaceVisit placeVisit) {
+        placeVisit.setId(UUID.randomUUID().toString().split("-")[0]);
+        if (placeVisit.getConsumedItems() != null) {
+            for (ConsumedItem item : placeVisit.getConsumedItems()) {
+                if (item.getId() == null) {
+                    item.setId(UUID.randomUUID().toString().split("-")[0]);
+                }
+            }
+        }
+        PlaceVisit saved = placeVisitRepository.save(placeVisit);
+        computePlaceSummary(saved.getPlaceId());
+        return new PlaceVisitResponse(saved, new ArrayList<>());
+    }
+
+    @Override
+    public List<PlaceVisitResponse> getPlaceVisits(String placeId) {
+        List<PlaceVisit> visits = placeVisitRepository.findByPlaceIdOrderByVisitedAtDesc(placeId);
+        return visits.stream()
+                .map(visit -> {
+                    List<UserVisit> userVisits = userVisitRepository.findByPlaceIdAndStatus(placeId, VisitStatus.VISITED)
+                            .stream()
+                            .filter(uv -> visit.getId().equals(uv.getPlaceVisitId()))
+                            .collect(Collectors.toList());
+                    List<CoVisitor> coVisitors = buildCoVisitorsFromUserVisits(userVisits);
+                    return new PlaceVisitResponse(visit, coVisitors);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public PlaceVisitResponse updatePlaceVisit(String visitId, PlaceVisit updates) {
+        PlaceVisit existing = placeVisitRepository.findById(visitId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "PlaceVisit not found: " + visitId));
+
+        if (updates.getVisitedAt() != null) existing.setVisitedAt(updates.getVisitedAt());
+        if (updates.getOwnerRating() != null) existing.setOwnerRating(updates.getOwnerRating());
+        if (updates.getPhotoUrls() != null) existing.setPhotoUrls(updates.getPhotoUrls());
+        if (updates.getConsumedItems() != null) {
+            for (ConsumedItem item : updates.getConsumedItems()) {
+                if (item.getId() == null) {
+                    item.setId(UUID.randomUUID().toString().split("-")[0]);
+                }
+            }
+            existing.setConsumedItems(updates.getConsumedItems());
+        }
+
+        PlaceVisit saved = placeVisitRepository.save(existing);
+        computePlaceSummary(saved.getPlaceId());
+
+        List<UserVisit> userVisits = userVisitRepository.findByPlaceIdAndStatus(saved.getPlaceId(), VisitStatus.VISITED)
+                .stream()
+                .filter(uv -> visitId.equals(uv.getPlaceVisitId()))
+                .collect(Collectors.toList());
+        List<CoVisitor> coVisitors = buildCoVisitorsFromUserVisits(userVisits);
+        return new PlaceVisitResponse(saved, coVisitors);
+    }
+
+    @Override
+    public void deletePlaceVisit(String visitId) {
+        PlaceVisit existing = placeVisitRepository.findById(visitId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "PlaceVisit not found: " + visitId));
+
+        String placeId = existing.getPlaceId();
+        long visitCount = placeVisitRepository.findByPlaceIdOrderByVisitedAtDesc(placeId).size();
+        if (visitCount <= 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot delete the only visit for this place");
+        }
+
+        // Delete linked UserVisit records
+        List<UserVisit> linkedUserVisits = userVisitRepository.findByPlaceIdAndStatus(placeId, VisitStatus.VISITED)
+                .stream()
+                .filter(uv -> visitId.equals(uv.getPlaceVisitId()))
+                .collect(Collectors.toList());
+        userVisitRepository.deleteAll(linkedUserVisits);
+
+        placeVisitRepository.deleteById(visitId);
+        computePlaceSummary(placeId);
+    }
+
+    @Override
+    public String uploadPlaceVisitPhoto(String visitId, byte[] fileBytes, String fileName) throws IOException {
+        PlaceVisit visit = placeVisitRepository.findById(visitId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "PlaceVisit not found: " + visitId));
+
+        String url = saveFile(visitId + "_" + fileName, fileBytes);
+
+        List<String> photoUrls = visit.getPhotoUrls() != null ? new ArrayList<>(visit.getPhotoUrls()) : new ArrayList<>();
+        photoUrls.add(url);
+        visit.setPhotoUrls(photoUrls);
+        placeVisitRepository.save(visit);
+
+        return url;
+    }
+
+    @Override
+    public String uploadConsumedItemPhoto(String visitId, String itemId, byte[] fileBytes, String fileName) throws IOException {
+        PlaceVisit visit = placeVisitRepository.findById(visitId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "PlaceVisit not found: " + visitId));
+
+        ConsumedItem targetItem = visit.getConsumedItems().stream()
+                .filter(item -> itemId.equals(item.getId()))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ConsumedItem not found: " + itemId));
+
+        String url = saveFile(visitId + "_item_" + itemId + "_" + fileName, fileBytes);
+
+        List<String> photoUrls = targetItem.getPhotoUrls() != null ? new ArrayList<>(targetItem.getPhotoUrls()) : new ArrayList<>();
+        photoUrls.add(url);
+        targetItem.setPhotoUrls(photoUrls);
+        placeVisitRepository.save(visit);
+
+        return url;
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private void computePlaceSummary(String placeId) {
+        List<PlaceVisit> visits = placeVisitRepository.findByPlaceIdOrderByVisitedAtDesc(placeId);
+        if (visits.isEmpty()) return;
+
+        Place place = placeRepository.findById(placeId).orElseThrow();
+
+        place.setVisitCount(visits.size());
+
+        double avgAmbient = visits.stream()
+                .filter(v -> v.getOwnerRating() != null)
+                .mapToDouble(v -> v.getOwnerRating().getAmbientRating())
+                .average().orElse(0);
+        double avgFood = visits.stream()
+                .filter(v -> v.getOwnerRating() != null)
+                .mapToDouble(v -> v.getOwnerRating().getFoodRating())
+                .average().orElse(0);
+        double avgPrice = visits.stream()
+                .filter(v -> v.getOwnerRating() != null)
+                .mapToDouble(v -> v.getOwnerRating().getPriceRating())
+                .average().orElse(0);
+        place.setAverageRating(new Rating(
+                Math.round(avgAmbient),
+                Math.round(avgFood),
+                Math.round(avgPrice),
+                Math.round(avgAmbient) + Math.round(avgFood) + Math.round(avgPrice)
+        ));
+
+        PlaceVisit latest = visits.get(0);
+        place.setRating(latest.getOwnerRating());
+        place.setVisitedAt(latest.getVisitedAt());
+        place.setLatestVisitedAt(latest.getVisitedAt());
+
+        placeRepository.save(place);
+    }
+
     private List<CoVisitor> assembleCoVisitors(String placeId) {
         List<UserVisit> visits = userVisitRepository.findByPlaceIdAndStatus(placeId, VisitStatus.VISITED);
         Set<String> visitUserIds = visits.stream()
@@ -137,7 +329,7 @@ public class PlaceManagerImpl implements PlaceManager {
                 .filter(cv -> cv != null)
                 .collect(Collectors.toList()));
 
-        // Include the place creator if they have no UserVisit (creators never go through the invitation flow)
+        // Include the place creator if they have no UserVisit
         placeRepository.findById(placeId).ifPresent(place -> {
             if (!visitUserIds.contains(place.getUserId())) {
                 userRepository.findById(place.getUserId()).ifPresent(creator ->
@@ -153,5 +345,31 @@ public class PlaceManagerImpl implements PlaceManager {
         });
 
         return coVisitors;
+    }
+
+    private List<CoVisitor> buildCoVisitorsFromUserVisits(List<UserVisit> userVisits) {
+        return userVisits.stream()
+                .map(uv -> {
+                    var user = userRepository.findById(uv.getUserId()).orElse(null);
+                    if (user == null) return null;
+                    return CoVisitor.builder()
+                            .userId(user.getId())
+                            .firstName(user.getFirstName())
+                            .lastName(user.getLastName())
+                            .profileImageUrl(user.getProfileImageUrl())
+                            .rating(uv.getRating())
+                            .build();
+                })
+                .filter(cv -> cv != null)
+                .collect(Collectors.toList());
+    }
+
+    private String saveFile(String fileName, byte[] fileBytes) throws IOException {
+        Path uploadDir = Paths.get("uploads");
+        if (!Files.exists(uploadDir)) {
+            Files.createDirectories(uploadDir);
+        }
+        Files.write(uploadDir.resolve(fileName), fileBytes);
+        return "/uploads/" + fileName;
     }
 }

--- a/src/main/java/places/service/VisitInvitationManager.java
+++ b/src/main/java/places/service/VisitInvitationManager.java
@@ -8,7 +8,7 @@ import places.model.VisitInvitation;
 import places.model.VisitInvitationDto;
 
 public interface VisitInvitationManager {
-    VisitInvitation sendInvitation(String inviterId, String placeId, String inviteeId);
+    VisitInvitation sendInvitation(String inviterId, String placeId, String inviteeId, String placeVisitId);
     List<VisitInvitationDto> getPendingInvitations(String userId);
     UserVisit acceptInvitation(String invitationId);
     void declineInvitation(String invitationId);

--- a/src/main/java/places/service/VisitInvitationManagerImpl.java
+++ b/src/main/java/places/service/VisitInvitationManagerImpl.java
@@ -37,7 +37,7 @@ public class VisitInvitationManagerImpl implements VisitInvitationManager {
     private final UserRepository userRepository;
 
     @Override
-    public VisitInvitation sendInvitation(String inviterId, String placeId, String inviteeId) {
+    public VisitInvitation sendInvitation(String inviterId, String placeId, String inviteeId, String placeVisitId) {
         boolean areFriends = friendshipRepository
                 .findByRequesterIdAndAddresseeId(inviterId, inviteeId)
                 .map(f -> f.getStatus() == FriendshipStatus.ACCEPTED)
@@ -67,6 +67,7 @@ public class VisitInvitationManagerImpl implements VisitInvitationManager {
                 .status(InvitationStatus.PENDING)
                 .createdAt(LocalDateTime.now())
                 .build();
+        invitation.setPlaceVisitId(placeVisitId);
 
         return visitInvitationRepository.save(invitation);
     }
@@ -107,6 +108,7 @@ public class VisitInvitationManagerImpl implements VisitInvitationManager {
                 .visitedAt(LocalDateTime.now())
                 .status(VisitStatus.PENDING)
                 .build();
+        visit.setPlaceVisitId(invitation.getPlaceVisitId());
 
         return userVisitRepository.save(visit);
     }


### PR DESCRIPTION
Introduces PlaceVisit as a first-class document for tracking multiple visits to a place. Places now aggregate visitCount, averageRating, and latestVisitedAt from their visits. VisitInvitation and UserVisit are linked to a specific PlaceVisit via placeVisitId for backward compat.

Cleanup: migrate PlaceVisit/ConsumedItem/PlaceVisitResponse to Lombok, remove redundant manual getters/setters from @Data classes, convert VisitController to @RequiredArgsConstructor, and extract duplicated file-upload logic into a private saveFile helper.